### PR TITLE
Adding a custom changelog line formatter

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,15 @@
 # lets-version
+
 A package that reads your conventional commits and git history and recommends (or applies) a SemVer version bump for you. Supports single-package repositories, as well as multi-package repositories!
 
 ---
+
 ## What is this package intending to be?
+
 If you have been relying on [lerna](https://www.npmjs.com/package/lerna) to automate your package version number managements, based on your commit history, or if you just want a hands-off way of applying version bumps to your `package.json` files in CI before you publish, this is the package for you!
 
 ---
+
 ## Example
 
 ```bash
@@ -34,6 +38,7 @@ Do you want to continue? › (y/N)
 ---
 
 ## CLI Documentation
+
 ```bash
 lets-version [command]
 
@@ -81,6 +86,7 @@ Options:
 ```
 
 ### `ls`
+
 Lists all detected packages for this repository.
 
 ```bash
@@ -99,6 +105,7 @@ Options:
 ```
 
 ### `last-version-tag`
+
 Gets the last tag used when version bumping for a specific package. If no package is specified, all found tags for each package detected are returned.
 
 ```bash
@@ -126,6 +133,7 @@ Options:
 ```
 
 ### `changed-files-since-bump`
+
 Gets a list of all files that have changed since the last publish for a specific package or set of packages. If no results are returned, it likely means that there was not a previous version tag detected in git.
 
 ```bash
@@ -154,6 +162,7 @@ Options:
 ```
 
 ### `changed-packages-since-bump`
+
 Gets a list of all packages that have changed since the last publish for a specific package or set of packages. If no results are returned, it likely means that there was not a previous version tag detected in git.
 
 ```bash
@@ -182,6 +191,7 @@ Options:
 ```
 
 ### `get-conventional-since-bump`
+
 Parsed git commits for a specific package or packages, using the official Conventional Commits parser
 
 ```bash
@@ -209,6 +219,7 @@ Options:
 ```
 
 ### `get-bumps`
+
 Gets a series of recommended version bumps for a specific package or set of packages. NOTE: It is possible for your bump recommendation to not change. If this is the case, this means that your particular package has never had a version bump by the lets-version library.
 
 ```bash
@@ -255,6 +266,7 @@ Options:
 ```
 
 ### `apply-bumps`
+
 Gets a series of recommended version bumps for a specific package or set of packages, applies the version bumps, and updates all repository dependents to match the version that has been updated.
 
 ```bash
@@ -312,6 +324,7 @@ Options:
       --updateOptional  If true, will update any dependent "package.json#optiona
                         lDependencies" fields         [boolean] [default: false]
 ```
+
 ---
 
 ## Node API
@@ -319,81 +332,91 @@ Options:
 The Node API is a 1:1 match for the CLI API, and can be used in its place. All exported functions accept the same arguments and product the same results. There are some additional functions that are available when using the Node API, if you're interested in exploring
 
 ### `listPackages(cwd)`
+
 Returns all detected packages for this repository
 
-* Parameters
-  * `cwd?: string` - Defaults to `appRootPath.toString()`
+- Parameters
+  - `cwd?: string` - Defaults to `appRootPath.toString()`
 
 ### `getLastVersionTagsByPackageName(names, noFetchTags, cwd)`
+
 Given an optional array of package names, reads the latest git tag that was used in a previous version bump operation.
 
-* Parameters
-  * `names?: string[]` - Defaults to `[]`
-  * `noFetchTags?: boolean` - Defaults to `false`
-  * `cwd?: string` - Defaults to `appRootPath.toString()`
+- Parameters
+  - `names?: string[]` - Defaults to `[]`
+  - `noFetchTags?: boolean` - Defaults to `false`
+  - `cwd?: string` - Defaults to `appRootPath.toString()`
 
 ### `getChangedFilesSinceBump(names, noFetchTags, cwd)`
+
 Gets a list of all files that have changed since the last publish for a specific package or set of packages. If no results are returned, it likely means that there was not a previous version tag detected in git.
 
-* Parameters
-  * `names?: string[]` - Defaults to `[]`
-  * `noFetchTags?: boolean` - Defaults to `false`
-  * `cwd?: string` - Defaults to `appRootPath.toString()`
+- Parameters
+  - `names?: string[]` - Defaults to `[]`
+  - `noFetchTags?: boolean` - Defaults to `false`
+  - `cwd?: string` - Defaults to `appRootPath.toString()`
 
 ### `getChangedPackagesSinceBump(names, noFetchTags, cwd)`
+
 Gets a list of all packages that have changed since the last publish for a specific package or set of packages. If no results are returned, it likely means that there was not a previous version tag detected in git.
 
-* Parameters
-  * `names?: string[]` - Defaults to `[]`
-  * `noFetchTags?: boolean` - Defaults to `false`
-  * `cwd?: string` - Defaults to `appRootPath.toString()`
+- Parameters
+  - `names?: string[]` - Defaults to `[]`
+  - `noFetchTags?: boolean` - Defaults to `false`
+  - `cwd?: string` - Defaults to `appRootPath.toString()`
 
 ### `getConventionalCommitsByPackage(names, cwd = appRootPath.toString())`
+
 Parses commits since last publish for a specific package or set of packages and returns them represented as Conventional Commits objects.
 
-* Parameters
-  * `names?: string[]` - Defaults to `[]`
-  * `cwd?: string` - Defaults to `appRootPath.toString()`
+- Parameters
+  - `names?: string[]` - Defaults to `[]`
+  - `cwd?: string` - Defaults to `appRootPath.toString()`
 
 ### `getRecommendedBumpsByPackage(names, releaseAs, preid, uniqify, forceAll, noFetchAll, noFetchTags, updatePeer, updateOptional, cwd)`
+
 Given an optional list of package names, parses the git history since the last bump operation and suggests a bump.
 NOTE: It is possible for your bump recommendation to not change. If this is the case, this means that your particular package has never had a version bump by the lets-version library.
 
-* Parameters
-  * `names?: string[]` - Defaults to `undefined`
-  * `releaseAs?: ReleaseAsPresets` - Defaults to `ReleaseAsPresets.AUTO`
-  * `preid?: string` - Defaults to `undefined`
-  * `uniqify?: boolean` - Defaults to `false`
-  * `forceAll?: boolean` - Defaults to `false`
-  * `noFetchAll?: boolean` - Defaults to `false`
-  * `noFetchTags?: boolean` - Defaults to `false`
-  * `updatePeer?: boolean` - Defaults to `false`
-  * `updateOptional?: boolean` - Defaults to `false`
-  * `cwd?: string` - Defaults to `appRootPath.toString()`
+- Parameters
+  - `names?: string[]` - Defaults to `undefined`
+  - `releaseAs?: ReleaseAsPresets` - Defaults to `ReleaseAsPresets.AUTO`
+  - `preid?: string` - Defaults to `undefined`
+  - `uniqify?: boolean` - Defaults to `false`
+  - `forceAll?: boolean` - Defaults to `false`
+  - `noFetchAll?: boolean` - Defaults to `false`
+  - `noFetchTags?: boolean` - Defaults to `false`
+  - `updatePeer?: boolean` - Defaults to `false`
+  - `updateOptional?: boolean` - Defaults to `false`
+  - `cwd?: string` - Defaults to `appRootPath.toString()`
 
 ### `applyRecommendedBumpsByPackage(names, releaseAs, preid, uniqify, forceAll, noFetchAll, noFetchTags, opts, cwd)`
+
 Given an optional list of package names, parses the git history since the last bump operation, suggest a bump and applies it, also updating any dependent package.json files across your repository.
 NOTE: It is possible for your bump recommendation to not change. If this is the case, this means that your particular package has never had a version bump by the lets-version library.
 
-* Parameters
-  * `names?: string[]` - Defaults to `undefined`
-  * `releaseAs?: ReleaseAsPresets` - Defaults to `ReleaseAsPresets.AUTO`
-  * `preid?: string` - Defaults to `undefined`
-  * `uniqify?: boolean` - Defaults to `false`
-  * `forceAll?: boolean` - Defaults to `false`
-  * `noFetchAll?: boolean` - Defaults to `false`
-  * `noFetchTags?: boolean` - Defaults to `false`
-  * `opts?: { yes?: boolean; updatePeer?: boolean; updateOptional?: boolean; noPush?: boolean; noChangelog?: boolean; dryRun?: boolean }` - Defaults to:
-    * `opts.yes` - If true, skips all user confirmations - Defaults to `false`
-    * `opts.updatePeer` - If true, will update any dependent "package.json#peerDependencies" fields - Defaults to `false`
-    * `opts.updateOptional` - If true, will update any dependent `"package.json#optionalDependencies"` fields - Defaults to `false`
-    * `opts.noPush` - If true, will prevent pushing any changes to upstream / origin - Defaults to `false`
-    * `opts.noChangelog` - If true, will not write CHANGELOG.md updates for each package that has changed. Defaults to `false`.
-    * `opts.dryRun` - If true, will print the changes that are expected to happen at every step instead of actually writing the changes. Defaults to `false`.
-  * `cwd?: string` - Defaults to `appRootPath.toString()`
+- Parameters
+  - `names?: string[]` - Defaults to `undefined`
+  - `releaseAs?: ReleaseAsPresets` - Defaults to `ReleaseAsPresets.AUTO`
+  - `preid?: string` - Defaults to `undefined`
+  - `uniqify?: boolean` - Defaults to `false`
+  - `forceAll?: boolean` - Defaults to `false`
+  - `noFetchAll?: boolean` - Defaults to `false`
+  - `noFetchTags?: boolean` - Defaults to `false`
+  - `opts?: { yes?: boolean; updatePeer?: boolean; updateOptional?: boolean; noPush?: boolean; noChangelog?: boolean; dryRun?: boolean; changelogLineFormatterPath?: string }` - Defaults to:
+    - `opts.yes` - If true, skips all user confirmations - Defaults to `false`
+    - `opts.updatePeer` - If true, will update any dependent "package.json#peerDependencies" fields - Defaults to `false`
+    - `opts.updateOptional` - If true, will update any dependent `"package.json#optionalDependencies"` fields - Defaults to `false`
+    - `opts.noPush` - If true, will prevent pushing any changes to upstream / origin - Defaults to `false`
+    - `opts.noChangelog` - If true, will not write CHANGELOG.md updates for each package that has changed. Defaults to `false`.
+    - `opts.dryRun` - If true, will print the changes that are expected to happen at every step instead of actually writing the changes. Defaults to `false`.
+    - `opts.changelogLineFormatterPath` - Path to a file to use as a custom changelog line formatter, the file must return a default export of a function that accepts a single argument of type "ChangelogLineFormatterArgs" and returns a string. Defaults to `undefined`.
+  - `cwd?: string` - Defaults to `appRootPath.toString()`
+
 ---
 
 ## Get started contributing
+
 1. Clone this repo
 2. Run `./repo-setup.sh`
 3. Happy hacking! ⌨️

--- a/src/__test__/changelogEntry.test.js
+++ b/src/__test__/changelogEntry.test.js
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest';
+
+import { ChangelogEntryType, ChangelogUpdateEntry, GitConventional } from '../types.js';
+
+describe('changelog entry tests', () => {
+  const sampleLines = [
+    new GitConventional({
+      body: 'body',
+      footer: 'footer',
+      header: 'header',
+      type: 'type',
+      scope: 'scope',
+      merge: 'merge',
+      notes: [{ title: 'title', text: 'text' }],
+      references: ['references'],
+      revert: null,
+      subject: 'subject',
+      sha: 'sha',
+      breaking: false,
+      mentions: ['mention'],
+    }),
+  ];
+
+  /**
+   * @param {GitConventional} line
+   * @returns {string}
+   */
+  const customFormatter = line => `- **${line.scope}** ${line.subject} (${line.sha})`;
+
+  it('should use the default formatter', () => {
+    const result = new ChangelogUpdateEntry(ChangelogEntryType.FEATURES, sampleLines);
+    expect(result.toString()).toBe('### ✨ Features ✨\n\n- subject (sha)');
+  });
+
+  it('should use the custom formatter', () => {
+    const result = new ChangelogUpdateEntry(ChangelogEntryType.FEATURES, sampleLines, customFormatter);
+    expect(result.toString()).toBe('### ✨ Features ✨\n\n- **scope** subject (sha)');
+  });
+});

--- a/src/changelog.js
+++ b/src/changelog.js
@@ -2,6 +2,7 @@
  * @typedef {import('./types.js').PackageInfo} PackageInfo
  * @typedef {import('./types.js').BumpRecommendation} BumpRecommendation
  * @typedef {import('./types.js').GitCommitWithConventionalAndPackageInfo} GitCommitWithConventionalAndPackageInfo
+ * @typedef {import('./types.js').ChangeLogLineFormatter} ChangeLogLineFormatter
  */
 
 import dayjs from 'dayjs';
@@ -20,6 +21,7 @@ import {
  * @typedef {Object} GenerateChangelogOpts
  * @property {BumpRecommendation[]} bumps
  * @property {GitCommitWithConventionalAndPackageInfo[]} commits
+ * @property {ChangeLogLineFormatter} [lineFormatter]
  */
 
 /**
@@ -87,7 +89,11 @@ export async function getChangelogUpdateForPackageInfo(opts) {
       processedConventionalForPackageName.add(packageName);
       toPush.entries = {
         ...toPush.entries,
-        [entryType]: new ChangelogUpdateEntry(entryType, [...(existingForEntry?.lines ?? []), c.conventional]),
+        [entryType]: new ChangelogUpdateEntry(
+          entryType,
+          [...(existingForEntry?.lines ?? []), c.conventional],
+          opts.lineFormatter,
+        ),
       };
     }
 
@@ -102,19 +108,23 @@ export async function getChangelogUpdateForPackageInfo(opts) {
 
     out.push(
       new ChangelogUpdate(getFormattedChangelogDate(), bump, {
-        [ChangelogEntryType.MISC]: new ChangelogUpdateEntry(ChangelogEntryType.MISC, [
-          new GitConventional({
-            body: null,
-            breaking: bump.type === BumpType.MAJOR || bump.type === BumpType.EXACT,
-            footer: null,
-            header:
-              bump.type === BumpType.EXACT ? `Version bumped exactly to ${bump.to}` : `Version bump forced for all`,
-            mentions: [],
-            merge: null,
-            notes: [],
-            sha: '',
-          }),
-        ]),
+        [ChangelogEntryType.MISC]: new ChangelogUpdateEntry(
+          ChangelogEntryType.MISC,
+          [
+            new GitConventional({
+              body: null,
+              breaking: bump.type === BumpType.MAJOR || bump.type === BumpType.EXACT,
+              footer: null,
+              header:
+                bump.type === BumpType.EXACT ? `Version bumped exactly to ${bump.to}` : `Version bump forced for all`,
+              mentions: [],
+              merge: null,
+              notes: [],
+              sha: '',
+            }),
+          ],
+          opts.lineFormatter,
+        ),
       }),
     );
   }

--- a/src/cli.js
+++ b/src/cli.js
@@ -22,6 +22,7 @@ import {
   listPackages,
 } from './lets-version.js';
 import { BumpTypeToString } from './types.js';
+import { readChangeLogLineFormatterFile } from './util.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -261,8 +262,16 @@ async function setupCLI() {
             default: false,
             description: 'If true, will update any dependent "package.json#optionalDependencies" fields',
             type: 'boolean',
+          })
+          .option('changelogLineFormatterPath', {
+            default: undefined,
+            description:
+              'Path to a file to use as a custom changelog line formatter, the file must return a default export of a function that accepts a single argument of type "ChangelogLineFormatterArgs" and returns a string',
+            type: 'string',
           }),
       async args => {
+        const formatter = await readChangeLogLineFormatterFile(args.changelogLineFormatterPath);
+
         await applyRecommendedBumpsByPackage(
           args.package,
           args.releaseAs,
@@ -278,6 +287,7 @@ async function setupCLI() {
             updateOptional: args.updateOptional,
             updatePeer: args.updatePeer,
             yes: args.yes,
+            changelogLineFormatter: formatter,
           },
           args.cwd,
         );

--- a/src/types.js
+++ b/src/types.js
@@ -404,6 +404,14 @@ export class BumpRecommendation {
 }
 
 /**
+ * A custom formatter that will take in a single commit line and return a formatted string
+ *
+ * @callback ChangeLogLineFormatter
+ * @param {GitConventional} line - The individual line to format
+ * @returns {string | null} The formatted line or null if you want to ignore the line
+ */
+
+/**
  * Represents a single type of changelog update
  * that should be included as part of a larger "ChangelogUpdate."
  * This individual entry should be written to a CHANGELOG.md file
@@ -413,13 +421,27 @@ export class ChangelogUpdateEntry {
   /**
    * @param {ChangelogEntryType} type
    * @param {GitConventional[]} lines
+   * @param {ChangeLogLineFormatter | null} formatter
    */
-  constructor(type, lines) {
+  constructor(type, lines, formatter = null) {
     /** @type {ChangelogEntryType} */
     this.type = type;
 
     /** @type {GitConventional[]} */
     this.lines = lines;
+
+    /** @type {ChangeLogLineFormatter} */
+    this.formatter = formatter || this.defaultFormatter;
+  }
+
+  /**
+   * Default formatter, will format each individual line of the changelog
+   *
+   * @param {GitConventional} line
+   * @returns {string}
+   */
+  defaultFormatter(line) {
+    return `- ${line.subject || line.header} ${line.sha ? `(${line.sha})` : ''}`;
   }
 
   /**
@@ -431,7 +453,8 @@ export class ChangelogUpdateEntry {
    */
   toString() {
     return `### ${this.type}${os.EOL}${os.EOL}${this.lines
-      .map(l => `* ${l.subject || l.header} ${l.sha ? `(${l.sha})` : ''}`)
+      .map(l => this.formatter(l))
+      .filter(Boolean)
       .join(os.EOL)}`;
   }
 }

--- a/src/util.js
+++ b/src/util.js
@@ -1,4 +1,11 @@
 /**
+ * @typedef {import('./types.js').ChangeLogLineFormatter} ChangeLogLineFormatter
+ */
+
+import fs from 'fs-extra';
+import path from 'path';
+
+/**
  * Pauses execution for a few moments before resolving
  *
  * @param {number} amount - Amount of milliseconds to sleep before resuming
@@ -30,4 +37,25 @@ export function chunkArray(arr, size = 5) {
   }
 
   return out;
+}
+
+/**
+ * Attempts to read the supplied path to a file that exports a ChangeLogLineFormatter
+ *
+ * @param {string | undefined} formatterPath
+ *
+ * @returns {Promise<ChangeLogLineFormatter | undefined>}
+ */
+export async function readChangeLogLineFormatterFile(formatterPath) {
+  if (formatterPath) {
+    const resolvedFormatterPath = path.resolve(process.cwd(), formatterPath);
+    const isFile = fs.statSync(resolvedFormatterPath, { throwIfNoEntry: false })?.isFile() || false;
+
+    if (isFile) {
+      const result = await import(resolvedFormatterPath);
+      return result.default;
+    }
+  }
+
+  return undefined;
 }


### PR DESCRIPTION
This change will allow the user to pass a custom formatter for the changelog line. This will allow the user to change the text, add links, etc.