### PR TITLE
Bduran/dont overload git

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 0.6.1-beta.1 (2023-06-28)
+
+### 🛠️ Fixes 🛠️
+
+- moved certain git operations to be synchronous to allow for easier caching and deduplication (e7a9c39affce692da61bd9e2bd0003b34893b42e)
+
+---
+
 ## 0.6.0 (2023-06-20)
 
 ### ✨ Features ✨

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@better-builds/lets-version",
-  "version": "0.6.0",
+  "version": "0.6.1-beta.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@better-builds/lets-version",
-      "version": "0.6.0",
+      "version": "0.6.1-beta.1",
       "license": "MIT",
       "dependencies": {
         "@npmcli/map-workspaces": "^3.0.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@better-builds/lets-version",
-  "version": "0.6.0",
+  "version": "0.6.1-beta.1",
   "description": "A package that reads your conventional commits and git history and recommends (or applies) a SemVer version bump for you",
   "exports": "./dist/lets-version.js",
   "bin": "./dist/cli.js",

--- a/src/exec.js
+++ b/src/exec.js
@@ -1,4 +1,4 @@
-import { execaCommand } from 'execa';
+import { execaCommand, execaCommandSync } from 'execa';
 
 /**
  * @typedef {Object} ExecAsyncOpts
@@ -18,4 +18,16 @@ export function execAsync(command, opts) {
   if (verbose) console.info('Executing', command, 'in', opts?.cwd);
 
   return execaCommand(command, opts);
+}
+
+/**
+ * @param {string} command
+ * @param {ExecAsyncOpts} opts
+ */
+export function execSync(command, opts) {
+  const verbose = process.env.LETS_VERSION_VERBOSE === 'true' || opts?.verbose || false;
+
+  if (verbose) console.info('Executing', command, 'in', opts?.cwd);
+
+  return execaCommandSync(command, opts);
 }


### PR DESCRIPTION
This fixes git being overloaded by multiple, de-duplicated calls to large operations like `git fetch origin`.