### PR TITLE
feat(changed-packages): enhanced cmd to print all files changed by package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,17 @@
+## 0.7.1-beta.0.d831ecc (2023-07-26)
+
+### 🛠️ Fixes 🛠️
+
+- fixed filtering of changes files by SHA to scope by the respective package (d831eccaa98137aace3c61bbd5d749c3b61835e9)
+
+
+
+### ✨ Features ✨
+
+- enhanced cmd to print all files changed by package (6b2cb13aefc744e6a9d92b44b8a72f665344dcd4)
+
+---
+
 ## 0.7.0 (2023-07-21)
 
 ### 🔀 Miscellaneous 🔀

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@better-builds/lets-version",
-  "version": "0.7.0",
+  "version": "0.7.1-beta.0.d831ecc",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@better-builds/lets-version",
-      "version": "0.7.0",
+      "version": "0.7.1-beta.0.d831ecc",
       "license": "MIT",
       "dependencies": {
         "@npmcli/map-workspaces": "^3.0.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@better-builds/lets-version",
-  "version": "0.7.0",
+  "version": "0.7.1-beta.0.d831ecc",
   "description": "A package that reads your conventional commits and git history and recommends (or applies) a SemVer version bump for you",
   "exports": "./dist/lets-version.js",
   "bin": "./dist/cli.js",

--- a/src/getPackages.js
+++ b/src/getPackages.js
@@ -99,9 +99,10 @@ export async function getAllPackagesChangedBasedOnFilesModified(filesModified, p
   for (const filePath of filesModified) {
     const touchedPackage = packagesToCheck.find(p => filePath.includes(p.packagePath));
     if (touchedPackage) {
+      const prevTrackedTouchedPackage = out.get(touchedPackage.name);
       const updatedPackage = new PackageInfo({
         ...touchedPackage,
-        filesChanged: [...(touchedPackage.filesChanged ?? []), filePath],
+        filesChanged: [...(prevTrackedTouchedPackage?.filesChanged ?? []), filePath],
       });
       out.set(touchedPackage.name, updatedPackage);
     }

--- a/src/lets-version.js
+++ b/src/lets-version.js
@@ -111,7 +111,7 @@ export async function getChangedFilesSinceBump(opts) {
 
   const tagResults = await getLastKnownPublishTagInfoForAllPackages(filteredPackages, noFetchTags, fixedCWD);
 
-  return getAllFilesChangedSinceTagInfos(tagResults, fixedCWD);
+  return getAllFilesChangedSinceTagInfos(filteredPackages, tagResults, fixedCWD);
 }
 
 /**
@@ -133,7 +133,7 @@ export async function getChangedPackagesSinceBump(opts) {
   if (!filteredPackages) return [];
 
   const tagInfos = await getLastKnownPublishTagInfoForAllPackages(filteredPackages, noFetchTags, fixedCWD);
-  const changedFiles = await getAllFilesChangedSinceTagInfos(tagInfos, fixedCWD);
+  const changedFiles = await getAllFilesChangedSinceTagInfos(filteredPackages, tagInfos, fixedCWD);
 
   /** @type {PackageInfo[]} */
   const allPackagesFilteredPlusRoot = [...filteredPackages];

--- a/src/lets-version.js
+++ b/src/lets-version.js
@@ -126,14 +126,22 @@ export async function getChangedPackagesSinceBump(opts) {
   const { names, noFetchTags = false, cwd = appRootPath.toString() } = opts ?? {};
   const fixedCWD = fixCWD(cwd);
 
-  const filteredPackages = await filterPackagesByNames(await getPackages(fixedCWD), names, fixedCWD);
+  const allPackages = await getPackages(fixedCWD);
+  const rootPackage = allPackages.find(p => p.root);
+  const filteredPackages = await filterPackagesByNames(allPackages, names, fixedCWD);
 
   if (!filteredPackages) return [];
 
   const tagInfos = await getLastKnownPublishTagInfoForAllPackages(filteredPackages, noFetchTags, fixedCWD);
   const changedFiles = await getAllFilesChangedSinceTagInfos(tagInfos, fixedCWD);
 
-  return getAllPackagesChangedBasedOnFilesModified(changedFiles, filteredPackages, fixedCWD);
+  /** @type {PackageInfo[]} */
+  const allPackagesFilteredPlusRoot = [...filteredPackages];
+  if (rootPackage) allPackagesFilteredPlusRoot.push(rootPackage);
+
+  const deduped = Array.from(new Map(allPackagesFilteredPlusRoot.map(p => [p.name, p])).values());
+
+  return getAllPackagesChangedBasedOnFilesModified(changedFiles, deduped, fixedCWD);
 }
 
 /**


### PR DESCRIPTION
## --byName Flag
```
widgets-professional-monorepo
  /Users/bduran/devlop/some-company/hp/package-lock.json
  /Users/bduran/devlop/some-company/hp/package.json

@widgets/components
  /Users/bduran/devlop/some-company/hp/packages/components/src/button/__docs__/examples/icon.example.tsx
  /Users/bduran/devlop/some-company/hp/packages/components/src/button/button.tsx
  /Users/bduran/devlop/some-company/hp/packages/components/src/feedback/__docs__/examples/icons.example.tsx
  /Users/bduran/devlop/some-company/hp/packages/components/src/hooks/useMenuTrigger.ts
  /Users/bduran/devlop/some-company/hp/packages/components/src/navigation/navigationMenuItem.tsx
  /Users/bduran/devlop/some-company/hp/packages/components/src/splitButton/__tests__/splitButton.test.tsx

@widgets/jest
  /Users/bduran/devlop/some-company/hp/packages/jest/src/widgetsProfessionalAudit.tsx
Default behavior
./
  /Users/bduran/devlop/some-company/hp/package-lock.json
  /Users/bduran/devlop/some-company/hp/package.json

./packages/components
  /Users/bduran/devlop/some-company/hp/packages/components/src/button/__docs__/examples/icon.example.tsx
  /Users/bduran/devlop/some-company/hp/packages/components/src/button/button.tsx
  /Users/bduran/devlop/some-company/hp/packages/components/src/feedback/__docs__/examples/icons.example.tsx
  /Users/bduran/devlop/some-company/hp/packages/components/src/hooks/useMenuTrigger.ts
  /Users/bduran/devlop/some-company/hp/packages/components/src/navigation/navigationMenuItem.tsx
  /Users/bduran/devlop/some-company/hp/packages/components/src/splitButton/__tests__/splitButton.test.tsx

./packages/jest
  /Users/bduran/devlop/some-company/hp/packages/jest/src/widgetsProfessionalAudit.tsx
```


## Default behavior

```
./
  /Users/bduran/devlop/some-company/hp/package-lock.json
  /Users/bduran/devlop/some-company/hp/package.json

./packages/components
  /Users/bduran/devlop/some-company/hp/packages/components/src/button/__docs__/examples/icon.example.tsx
  /Users/bduran/devlop/some-company/hp/packages/components/src/button/button.tsx
  /Users/bduran/devlop/some-company/hp/packages/components/src/feedback/__docs__/examples/icons.example.tsx
  /Users/bduran/devlop/some-company/hp/packages/components/src/hooks/useMenuTrigger.ts
  /Users/bduran/devlop/some-company/hp/packages/components/src/navigation/navigationMenuItem.tsx
  /Users/bduran/devlop/some-company/hp/packages/components/src/splitButton/__tests__/splitButton.test.tsx

./packages/jest
  /Users/bduran/devlop/some-company/hp/packages/jest/src/widgetsProfessionalAudit.tsx
```