### PR TITLE
Bduran/no push not respected

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 0.7.4-beta.0 (2023-09-28)
+
+### 🛠️ Fixes 🛠️
+
+- nopush and nocommit are not properly respected (65e5f53229d4762c412bda5e33f468ad0115248d)
+
+---
+
 ## 0.7.3 (2023-09-28)
 
 ### 🔀 Miscellaneous 🔀

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 0.7.4-beta.1 (2023-09-28)
+
+### ✨ Features ✨
+
+- added 'noInstall' flag to opt-into avoiding npm install after the version bump operation (9431a6d2ee4db73f312effb923e65fedd9c49acc)
+
+---
+
 ## 0.7.4-beta.0 (2023-09-28)
 
 ### 🛠️ Fixes 🛠️

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ Options:
   --help     Show help                                                 [boolean]
   --cwd      The folder to use as root when running command. Defaults to your se
              ssion's CWD
-       [string] [default: "/Users/benjaminduran/devlop/opensource/lets-version"]
+
   --json     If true, lists results as a JSON blob piped to your terminal
                                                       [boolean] [default: false]
 ```
@@ -129,7 +129,7 @@ Options:
   --help     Show help                                                 [boolean]
   --cwd      The folder to use as root when running command. Defaults to your se
              ssion's CWD
-       [string] [default: "/Users/benjaminduran/devlop/opensource/lets-version"]
+
   --json     If true, lists results as a JSON blob piped to your terminal
                                                       [boolean] [default: false]
 ```
@@ -149,7 +149,7 @@ Options:
       --help         Show help                                         [boolean]
       --cwd          The folder to use as root when running command. Defaults to
                       your session's CWD
-       [string] [default: "/Users/benjaminduran/devlop/opensource/lets-version"]
+
       --json         If true, lists results as a JSON blob piped to your termina
                      l                                [boolean] [default: false]
   -p, --package      One or more packages to check. You can specify multiple by
@@ -178,7 +178,7 @@ Options:
       --help         Show help                                         [boolean]
       --cwd          The folder to use as root when running command. Defaults to
                       your session's CWD
-       [string] [default: "/Users/benjaminduran/devlop/opensource/lets-version"]
+
       --json         If true, lists results as a JSON blob piped to your termina
                      l                                [boolean] [default: false]
   -p, --package      One or more packages to check. You can specify multiple by
@@ -207,7 +207,7 @@ Options:
       --help         Show help                                         [boolean]
       --cwd          The folder to use as root when running command. Defaults to
                       your session's CWD
-       [string] [default: "/Users/benjaminduran/devlop/opensource/lets-version"]
+
       --json         If true, lists results as a JSON blob piped to your termina
                      l                                [boolean] [default: false]
   -p, --package      One or more packages to check. You can specify multiple by
@@ -238,7 +238,7 @@ Options:
       --help         Show help                                         [boolean]
       --cwd          The folder to use as root when running command. Defaults to
                       your session's CWD
-       [string] [default: "/Users/benjaminduran/devlop/opensource/lets-version"]
+
       --json         If true, lists results as a JSON blob piped to your termina
                      l                                [boolean] [default: false]
   -p, --package      One or more packages to check. You can specify multiple by
@@ -268,7 +268,7 @@ Options:
       --help            Show help                                      [boolean]
       --cwd             The folder to use as root when running command. Defaults
                          to your session's CWD
-       [string] [default: "/Users/benjaminduran/devlop/opensource/lets-version"]
+
       --json            If true, lists results as a JSON blob piped to your term
                         inal                          [boolean] [default: false]
   -p, --package         One or more packages to check. You can specify multiple
@@ -318,7 +318,7 @@ Options:
       --help              Show help                                    [boolean]
       --cwd               The folder to use as root when running command. Defaul
                           ts to your session's CWD
-       [string] [default: "/Users/benjaminduran/devlop/opensource/lets-version"]
+
       --json              If true, lists results as a JSON blob piped to your te
                           rminal                      [boolean] [default: false]
   -p, --package           One or more packages to check. You can specify multipl
@@ -394,7 +394,7 @@ Options:
       --help     Show help                                             [boolean]
       --cwd      The folder to use as root when running command. Defaults to you
                  r session's CWD
-       [string] [default: "/Users/benjaminduran/devlop/opensource/lets-version"]
+
       --json     If true, lists results as a JSON blob piped to your terminal
                                                       [boolean] [default: false]
   -b, --branch   Name of the branch to check against. [string] [default: "main"]
@@ -416,7 +416,7 @@ Options:
       --help     Show help                                             [boolean]
       --cwd      The folder to use as root when running command. Defaults to you
                  r session's CWD
-       [string] [default: "/Users/benjaminduran/devlop/opensource/lets-version"]
+
       --json     If true, lists results as a JSON blob piped to your terminal
                                                       [boolean] [default: false]
   -b, --branch   Name of the branch to check against. [string] [default: "main"]

--- a/README.md
+++ b/README.md
@@ -84,6 +84,10 @@ Commands:
                                             mps, and updates all repository depe
                                             ndents to match the version that has
                                              been updated.
+  lets-version changed-files-since-branch   Gets a list of all files that have c
+                                            hanged in the current branch.
+  lets-version changed-packages-since-bran  Gets a list of all packages that hav
+  ch                                        e changed in the current branch.
 
 Options:
   --version  Show version number                                       [boolean]
@@ -104,7 +108,7 @@ Options:
   --help     Show help                                                 [boolean]
   --cwd      The folder to use as root when running command. Defaults to your se
              ssion's CWD
-              [string] [default: "/Users/bduran/devlop/opensource/lets-version"]
+       [string] [default: "/Users/benjaminduran/devlop/opensource/lets-version"]
   --json     If true, lists results as a JSON blob piped to your terminal
                                                       [boolean] [default: false]
 ```
@@ -125,7 +129,7 @@ Options:
   --help     Show help                                                 [boolean]
   --cwd      The folder to use as root when running command. Defaults to your se
              ssion's CWD
-              [string] [default: "/Users/bduran/devlop/opensource/lets-version"]
+       [string] [default: "/Users/benjaminduran/devlop/opensource/lets-version"]
   --json     If true, lists results as a JSON blob piped to your terminal
                                                       [boolean] [default: false]
 ```
@@ -145,7 +149,7 @@ Options:
       --help         Show help                                         [boolean]
       --cwd          The folder to use as root when running command. Defaults to
                       your session's CWD
-              [string] [default: "/Users/bduran/devlop/opensource/lets-version"]
+       [string] [default: "/Users/benjaminduran/devlop/opensource/lets-version"]
       --json         If true, lists results as a JSON blob piped to your termina
                      l                                [boolean] [default: false]
   -p, --package      One or more packages to check. You can specify multiple by
@@ -174,7 +178,7 @@ Options:
       --help         Show help                                         [boolean]
       --cwd          The folder to use as root when running command. Defaults to
                       your session's CWD
-              [string] [default: "/Users/bduran/devlop/opensource/lets-version"]
+       [string] [default: "/Users/benjaminduran/devlop/opensource/lets-version"]
       --json         If true, lists results as a JSON blob piped to your termina
                      l                                [boolean] [default: false]
   -p, --package      One or more packages to check. You can specify multiple by
@@ -203,7 +207,7 @@ Options:
       --help         Show help                                         [boolean]
       --cwd          The folder to use as root when running command. Defaults to
                       your session's CWD
-              [string] [default: "/Users/bduran/devlop/opensource/lets-version"]
+       [string] [default: "/Users/benjaminduran/devlop/opensource/lets-version"]
       --json         If true, lists results as a JSON blob piped to your termina
                      l                                [boolean] [default: false]
   -p, --package      One or more packages to check. You can specify multiple by
@@ -214,6 +218,9 @@ Options:
                       lets-version will do "git fetch origin --tags --force" to
                      ensure your branch if up-to-date with the tags on origin
                                                       [boolean] [default: false]
+      --byName       If true and the --json flag has not been set, reports the c
+                     hanged packages by their package.json names, instead of by
+                     their relative file paths        [boolean] [default: false]
 ```
 
 ### `get-conventional-since-bump`
@@ -231,7 +238,7 @@ Options:
       --help         Show help                                         [boolean]
       --cwd          The folder to use as root when running command. Defaults to
                       your session's CWD
-              [string] [default: "/Users/bduran/devlop/opensource/lets-version"]
+       [string] [default: "/Users/benjaminduran/devlop/opensource/lets-version"]
       --json         If true, lists results as a JSON blob piped to your termina
                      l                                [boolean] [default: false]
   -p, --package      One or more packages to check. You can specify multiple by
@@ -261,7 +268,7 @@ Options:
       --help            Show help                                      [boolean]
       --cwd             The folder to use as root when running command. Defaults
                          to your session's CWD
-              [string] [default: "/Users/bduran/devlop/opensource/lets-version"]
+       [string] [default: "/Users/benjaminduran/devlop/opensource/lets-version"]
       --json            If true, lists results as a JSON blob piped to your term
                         inal                          [boolean] [default: false]
   -p, --package         One or more packages to check. You can specify multiple
@@ -302,63 +309,122 @@ Gets a series of recommended version bumps for a specific package or set of pack
 ```bash
 lets-version apply-bumps
 
-lets-version apply-bumps
-
 Gets a series of recommended version bumps for a specific package or set of pack
 ages, applies the version bumps, and updates all repository dependents to match
 the version that has been updated.
 
 Options:
-      --version          Show version number                           [boolean]
-      --help             Show help                                     [boolean]
-      --cwd              The folder to use as root when running command. Default
-                         s to your session's CWD
-              [string] [default: "/Users/bduran/devlop/opensource/lets-version"]
-      --json             If true, lists results as a JSON blob piped to your ter
-                         minal                        [boolean] [default: false]
-  -p, --package          One or more packages to check. You can specify multiple
-                          by doing -p <name1> -p <name2> -p <name3>      [array]
-      --noFetchAll       If true, will not fetch information from remote via "gi
-                         t fetch origin"              [boolean] [default: false]
-      --noFetchTags      If true, does not force fetch tags from origin. By defa
-                         ult, lets-version will do "git fetch origin --tags --fo
-                         rce" to ensure your branch if up-to-date with the tags
-                         on origin                    [boolean] [default: false]
-      --releaseAs        Releases each changed package as this release type or a
-                         s an exact version. "major" "minor" "patch" "alpha" "be
-                         ta" "auto" or an exact semver version number are allowe
-                         d.                           [string] [default: "auto"]
-      --preid            The "prerelease identifier" to use as a prefix for the
-                         "prerelease" part of a semver. Like the rc in 1.2.0-rc.
-                         8. If this is specified, a bump type of "prerelease" wi
-                         ll always take place, causing any "--releaseAs" setting
-                          to be ignored.                                [string]
-      --uniqify          If true, will append the git SHA at version bunp time t
-                         o the end of the version number (while maintaining vali
-                         d semver)                    [boolean] [default: false]
-      --forceAll         If true, forces all packages to receive a bump update,
-                         regardless of whether they have changed. What this mean
-                         s, in practice, is that any package that would not norm
-                         ally be changed will receive a PATCH update (or an equi
-                         valent if --preid is set)    [boolean] [default: false]
-      --updatePeer       If true, will update any dependent "package.json#peerDe
-                         pendencies" fields           [boolean] [default: false]
-      --updateOptional   If true, will update any dependent "package.json#option
-                         alDependencies" fields       [boolean] [default: false]
-  -y, --yes              If true, skips any confirmation prompts. Useful if you
-                         need to automate this process in CI
+      --version           Show version number                          [boolean]
+      --help              Show help                                    [boolean]
+      --cwd               The folder to use as root when running command. Defaul
+                          ts to your session's CWD
+       [string] [default: "/Users/benjaminduran/devlop/opensource/lets-version"]
+      --json              If true, lists results as a JSON blob piped to your te
+                          rminal                      [boolean] [default: false]
+  -p, --package           One or more packages to check. You can specify multipl
+                          e by doing -p <name1> -p <name2> -p <name3>    [array]
+      --noFetchAll        If true, will not fetch information from remote via "g
+                          it fetch origin"            [boolean] [default: false]
+      --noFetchTags       If true, does not force fetch tags from origin. By def
+                          ault, lets-version will do "git fetch origin --tags --
+                          force" to ensure your branch if up-to-date with the ta
+                          gs on origin                [boolean] [default: false]
+      --releaseAs         Releases each changed package as this release type or
+                          as an exact version. "major" "minor" "patch" "alpha" "
+                          beta" "auto" or an exact semver version number are all
+                          owed.                       [string] [default: "auto"]
+      --preid             The "prerelease identifier" to use as a prefix for the
+                           "prerelease" part of a semver. Like the rc in 1.2.0-r
+                          c.8. If this is specified, a bump type of "prerelease"
+                           will always take place, causing any "--releaseAs" set
+                          ting to be ignored.                           [string]
+      --uniqify           If true, will append the git SHA at version bunp time
+                          to the end of the version number (while maintaining va
+                          lid semver)                 [boolean] [default: false]
+      --forceAll          If true, forces all packages to receive a bump update,
+                           regardless of whether they have changed. What this me
+                          ans, in practice, is that any package that would not n
+                          ormally be changed will receive a PATCH update (or an
+                          equivalent if --preid is set)
                                                       [boolean] [default: false]
-      --dryRun           If true, will print the changes that are expected to ha
-                         ppen at every step instead of actually writing the chan
-                         ges                          [boolean] [default: false]
-      --rollupChangelog  If true, in addition to updating changelog files for al
-                         l packages that will be bumped, creates a "rollup" CHAN
-                         GELOG.md at the root of the repo that contains an aggre
-                         gate of changes              [boolean] [default: false]
-      --noChangelog      If true, will not write CHANGELOG.md updates for each p
-                         ackage that has changed      [boolean] [default: false]
-      --noPush           If true, will not push changes and tags to origin
+      --updatePeer        If true, will update any dependent "package.json#peerD
+                          ependencies" fields         [boolean] [default: false]
+      --updateOptional    If true, will update any dependent "package.json#optio
+                          nalDependencies" fields     [boolean] [default: false]
+      --allowUncommitted  If true, will allow the version operation to continue
+                          when there are uncommitted files in the repo at versio
+                          n bump time. This is usefull if you have some scripts
+                          that need to run after version bumps are performed, bu
+                          t potentially before you issue a git commit and subseq
+                          uent npm publish operation. [boolean] [default: false]
+      --dryRun            If true, will print the changes that are expected to h
+                          appen at every step instead of actually writing the ch
+                          anges                       [boolean] [default: false]
+      --rollupChangelog   If true, in addition to updating changelog files for a
+                          ll packages that will be bumped, creates a "rollup" CH
+                          ANGELOG.md at the root of the repo that contains an ag
+                          gregate of changes          [boolean] [default: false]
+      --noChangelog       If true, will not write CHANGELOG.md updates for each
+                          package that has changed    [boolean] [default: false]
+      --noCommit          If true, will modify all required files but leave them
+                           uncommitted after all operations have completed. This
+                           will also prevent a git push from occurring
                                                       [boolean] [default: false]
+      --noInstall         If true, will skip running "npm install" or your packa
+                          ge manager's equivalent install after applying the bum
+                          ps                          [boolean] [default: false]
+      --noPush            If true, will not push changes and tags to origin
+                                                      [boolean] [default: false]
+  -y, --yes               If true, skips any confirmation prompts. Useful if you
+                           need to automate this process in CI
+                                                      [boolean] [default: false]
+```
+
+### `changed-files-since-branch`
+
+Gets a list of all files that have changed in the current branch.
+
+```bash
+lets-version changed-files-since-branch
+
+Gets a list of all files that have changed in the current branch.
+
+Options:
+      --version  Show version number                                   [boolean]
+      --help     Show help                                             [boolean]
+      --cwd      The folder to use as root when running command. Defaults to you
+                 r session's CWD
+       [string] [default: "/Users/benjaminduran/devlop/opensource/lets-version"]
+      --json     If true, lists results as a JSON blob piped to your terminal
+                                                      [boolean] [default: false]
+  -b, --branch   Name of the branch to check against. [string] [default: "main"]
+  -p, --package  One or more packages to check. You can specify multiple by doin
+                 g -p <name1> -p <name2> -p <name3>                      [array]
+```
+
+### `changed-packages-since-branch`
+
+Gets a list of all packages that have changed in the current branch.
+
+```bash
+lets-version changed-packages-since-branch
+
+Gets a list of all packages that have changed in the current branch.
+
+Options:
+      --version  Show version number                                   [boolean]
+      --help     Show help                                             [boolean]
+      --cwd      The folder to use as root when running command. Defaults to you
+                 r session's CWD
+       [string] [default: "/Users/benjaminduran/devlop/opensource/lets-version"]
+      --json     If true, lists results as a JSON blob piped to your terminal
+                                                      [boolean] [default: false]
+  -b, --branch   Name of the branch to check against. [string] [default: "main"]
+  -p, --package  One or more packages to check. You can specify multiple by doin
+                 g -p <name1> -p <name2> -p <name3>                      [array]
+      --byName   If true and the --json flag has not been set, reports the chang
+                 ed packages by their package.json names, instead of by their re
+                 lative file paths                    [boolean] [default: false]
 ```
 
 ---
@@ -447,6 +513,24 @@ NOTE: It is possible for your bump recommendation to not change. If this is the 
   - `opts?.noChangelog` - If true, will not write CHANGELOG.md updates for each package that has changed. Defaults to `false`.
   - `opts?.dryRun` - If true, will print the changes that are expected to happen at every step instead of actually writing the changes. Defaults to `false`.
     array of change log entries and returns the full changelog entry string. Defaults to `undefined`.
+  - `opts?.cwd?: string` - Defaults to `appRootPath.toString()`
+
+### `getChangedFilesSinceBranch(opts)`
+
+Gets a list of all files that have changed since the current branch was created.
+
+- Parameters
+  - `opts?.branch?: string` - Defaults to `main`
+  - `opts?.names?: string[]` - Defaults to `undefined`
+  - `opts?.cwd?: string` - Defaults to `appRootPath.toString()`
+
+### `getChangedPackagesSinceBranch(opts)`
+
+Gets a list of all packages that have changed since the current branch was created.
+
+- Parameters
+  - `opts?.branch?: string` - Defaults to `main`
+  - `opts?.names?: string[]` - Defaults to `undefined`
   - `opts?.cwd?: string` - Defaults to `appRootPath.toString()`
 
 ---

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@better-builds/lets-version",
-  "version": "0.7.3",
+  "version": "0.7.4-beta.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@better-builds/lets-version",
-      "version": "0.7.3",
+      "version": "0.7.4-beta.0",
       "license": "MIT",
       "dependencies": {
         "@npmcli/map-workspaces": "^3.0.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@better-builds/lets-version",
-  "version": "0.7.4-beta.0",
+  "version": "0.7.4-beta.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@better-builds/lets-version",
-      "version": "0.7.4-beta.0",
+      "version": "0.7.4-beta.1",
       "license": "MIT",
       "dependencies": {
         "@npmcli/map-workspaces": "^3.0.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@better-builds/lets-version",
-  "version": "0.7.4-beta.0",
+  "version": "0.7.4-beta.1",
   "description": "A package that reads your conventional commits and git history and recommends (or applies) a SemVer version bump for you",
   "exports": "./dist/lets-version.js",
   "bin": "./dist/cli.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@better-builds/lets-version",
-  "version": "0.7.3",
+  "version": "0.7.4-beta.0",
   "description": "A package that reads your conventional commits and git history and recommends (or applies) a SemVer version bump for you",
   "exports": "./dist/lets-version.js",
   "bin": "./dist/cli.js",

--- a/src/cli.js
+++ b/src/cli.js
@@ -392,6 +392,11 @@ async function setupCLI() {
               'If true, will modify all required files but leave them uncommitted after all operations have completed. This will also prevent a git push from occurring',
             type: 'boolean',
           })
+          .option('noInstall', {
+            default: false,
+            description: `If true, will skip running "npm install" or your package manager's equivalent install after applying the bumps`,
+            type: 'boolean',
+          })
           .option('noPush', {
             default: false,
             description: 'If true, will not push changes and tags to origin',
@@ -414,6 +419,7 @@ async function setupCLI() {
           noCommit: args.noCommit,
           noFetchAll: args.noFetchAll,
           noFetchTags: args.noFetchTags,
+          noInstall: args.noInstall,
           noPush: args.noPush,
           preid: args.preid,
           releaseAs: args.releaseAs,

--- a/src/lets-version.js
+++ b/src/lets-version.js
@@ -519,7 +519,9 @@ export async function applyRecommendedBumpsByPackage(opts) {
       b =>
         `package: ${b.packageInfo.name}${os.EOL}  bump: ${b.from ? `${b.from} -> ${b.to}` : `First time -> ${b.to}`}${
           os.EOL
-        }  type: ${BumpTypeToString[b.type]}${os.EOL}  valid: ${b.isValid}`,
+        }  type: ${BumpTypeToString[b.type]}${os.EOL}  valid: ${b.isValid}${os.EOL}  private: ${
+          b.packageInfo.isPrivate
+        }`,
     )
     .join(`${os.EOL}${os.EOL}`);
   if (!yes) {


### PR DESCRIPTION
Additionally, this introduces a `--noInstall` flag to the `apply-bumps` command that skips running the lockfile synchronization step