### PR TITLE
Pass --saveExact through applyRecommendedBumpsByPackage

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -41,6 +41,7 @@
         "husky": "^8.0.3",
         "lint-staged": "^13.2.2",
         "npm-run-all": "^4.1.5",
+        "pnpm": "^9.0.6",
         "tsup": "^6.7.0",
         "type-fest": "^3.11.1",
         "typescript": "^5.1.3",
@@ -8368,6 +8369,22 @@
         "jsonc-parser": "^3.2.0",
         "mlly": "^1.2.0",
         "pathe": "^1.1.0"
+      }
+    },
+    "node_modules/pnpm": {
+      "version": "9.0.6",
+      "resolved": "https://registry.npmjs.org/pnpm/-/pnpm-9.0.6.tgz",
+      "integrity": "sha512-9thjEwlzIHy3ozbWtDmiQqJqyAaAd99TDWqGBpQZhT3B/+ZAKexZSpxQWjpBDRlkPIcKumd2Mw9c/dzxCpwWFw==",
+      "dev": true,
+      "bin": {
+        "pnpm": "bin/pnpm.cjs",
+        "pnpx": "bin/pnpx.cjs"
+      },
+      "engines": {
+        "node": ">=18.12"
+      },
+      "funding": {
+        "url": "https://opencollective.com/pnpm"
       }
     },
     "node_modules/postcss": {

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "husky": "^8.0.3",
     "lint-staged": "^13.2.2",
     "npm-run-all": "^4.1.5",
+    "pnpm": "^9.0.6",
     "tsup": "^6.7.0",
     "type-fest": "^3.11.1",
     "typescript": "^5.1.3",

--- a/src/lets-version.js
+++ b/src/lets-version.js
@@ -479,6 +479,7 @@ export async function applyRecommendedBumpsByPackage(opts) {
     releaseAs = ReleaseAsPresets.AUTO,
     rollupChangelog = false,
     uniqify = false,
+    saveExact = false,
     updateOptional = false,
     updatePeer = false,
   } = opts ?? {};
@@ -512,6 +513,7 @@ export async function applyRecommendedBumpsByPackage(opts) {
     releaseAs,
     preid,
     uniqify,
+    saveExact,
     forceAll,
     noFetchAll,
     noFetchTags,


### PR DESCRIPTION
Previously --saveExact from turbo-tools was being dropped in `applyRecommendedBumpsByPackage`. With this change, it makes it all the way through to `synchronizeBumps` as desired!

Testing: rebuilt lets-version locally and then in the monorepo ran
```
npx turbo-tools version --yes --noCommit --noPush --releaseAs alpha --uniqify --saveExact
...
```

And it worked!
```
diff --git a/package-lock.json b/package-lock.json
index 2c7a150139..6c3a95fc72 100644
--- a/package-lock.json
+++ b/package-lock.json
...
-        "package-name": "^0.0.1-alpha.0.cfaa18afeb",
+        "package-name": "0.0.1-alpha.0.f604b52558",
```

Also had some trouble running the tests locally because I did not have `pnpm` installed, so added it to the devDependencies.