### PR TITLE
fix: apply missing bumps to deps for dependents

### DIFF
--- a/src/dependencies.ts
+++ b/src/dependencies.ts
@@ -159,6 +159,10 @@ export async function synchronizeBumps(
           ) {
             operatorTouse = '^';
           }
+
+          // @ts-expect-error - silence tsc because accessors here are safe, as we've already checked for key existence
+          dependent.pkg[dependentPjsonKey][dependentDepName] = `${operatorTouse}${bump.to}`;
+
           const existingChildBumpRec = bumpsByPackageName.get(dependent.name);
           const childBumpRec = await getBumpRecommendationForPackageInfo(
             dependent,


### PR DESCRIPTION
# What?

A recent update to `lets-version` accidentally omitted code that would apply dependency updates to children when a parents changes. This corrects this issue