### PR TITLE
chore: add the new line indent when creating the packageJson file

### DIFF
--- a/src/writePackageJSON.ts
+++ b/src/writePackageJSON.ts
@@ -1,5 +1,5 @@
 import path from 'node:path';
-
+import os from 'node:os';
 import detectIndent from 'detect-indent';
 import fs from 'fs-extra';
 import type { PackageJson } from 'type-fest';
@@ -13,5 +13,5 @@ export async function writePackageJSON(contents: PackageJson, filePath: string) 
   const ogPackageJson = await fs.readFile(p, 'utf-8');
 
   const indent = detectIndent(ogPackageJson);
-  await fs.writeFile(p, JSON.stringify(contents, null, indent.indent ?? '  ') + '\n', 'utf-8');
+  await fs.writeFile(p, `${JSON.stringify(contents, null, indent.indent ?? ' ')}${os.EOL}`, 'utf-8');
 }

--- a/src/writePackageJSON.ts
+++ b/src/writePackageJSON.ts
@@ -13,5 +13,5 @@ export async function writePackageJSON(contents: PackageJson, filePath: string) 
   const ogPackageJson = await fs.readFile(p, 'utf-8');
 
   const indent = detectIndent(ogPackageJson);
-  await fs.writeFile(p, JSON.stringify(contents, null, indent.indent ?? '  '), 'utf-8');
+  await fs.writeFile(p, JSON.stringify(contents, null, indent.indent ?? '  ') + '\n', 'utf-8');
 }


### PR DESCRIPTION
Some of the eslint rules may require the new line by the end of each file. Which is a nice practice in general. 
This small PR addresses just that :) 