### PR TITLE
Add a way to specify non-js dependencies for a package

### DIFF
--- a/src/__test__/additionalPaths.test.ts
+++ b/src/__test__/additionalPaths.test.ts
@@ -1,0 +1,163 @@
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { describe, expect, it } from 'vitest';
+
+import { getAllPackagesChangedBasedOnFilesModified } from '../getPackages.js';
+import { listPackages } from '../lets-version.js';
+import { PackageInfo } from '../types.js';
+import { isUnderPath } from '../util.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+describe('isUnderPath', () => {
+  it('should match files directly inside the base path', () => {
+    expect(isUnderPath('/repo/src/file.ts', '/repo/src')).toBe(true);
+  });
+
+  it('should match files in nested subdirectories', () => {
+    expect(isUnderPath('/repo/src/deep/nested/file.ts', '/repo/src')).toBe(true);
+  });
+
+  it('should not match paths that share a prefix but differ at a directory boundary', () => {
+    expect(isUnderPath('/repo/src-other/file.ts', '/repo/src')).toBe(false);
+  });
+
+  it('should handle base paths with trailing separators', () => {
+    expect(isUnderPath('/repo/src/file.ts', '/repo/src/')).toBe(true);
+  });
+
+  it('should match when filePath equals basePath exactly', () => {
+    expect(isUnderPath('/repo/src', '/repo/src')).toBe(true);
+  });
+
+  it('should not match unrelated paths', () => {
+    expect(isUnderPath('/other/path/file.ts', '/repo/src')).toBe(false);
+  });
+});
+
+describe('additionalPaths support', () => {
+  const projectPath = path.join(__dirname, './dummyProjects/multiNPMWithAdditionalPaths');
+
+  it('should read additionalPaths from letsVersion.config.mjs and populate allPaths', async () => {
+    const packages = await listPackages({ cwd: projectPath });
+
+    const wasmPkg = packages.find(p => p.name === 'wasm-pkg');
+    const anotherWasmPkg = packages.find(p => p.name === 'another-wasm-pkg');
+    const regularPkg = packages.find(p => p.name === 'regular-pkg');
+
+    expect(wasmPkg).toBeDefined();
+    expect(anotherWasmPkg).toBeDefined();
+    expect(regularPkg).toBeDefined();
+
+    const expectedExternalPath = path.resolve(projectPath, 'external-src');
+
+    expect(wasmPkg!.additionalPaths).toEqual([expectedExternalPath]);
+    expect(wasmPkg!.allPaths).toEqual([wasmPkg!.packagePath, expectedExternalPath]);
+
+    expect(anotherWasmPkg!.additionalPaths).toEqual([expectedExternalPath]);
+    expect(anotherWasmPkg!.allPaths).toEqual([anotherWasmPkg!.packagePath, expectedExternalPath]);
+
+    expect(regularPkg!.additionalPaths).toEqual([]);
+    expect(regularPkg!.allPaths).toEqual([regularPkg!.packagePath]);
+  });
+
+  it('should detect changed packages when files in additionalPaths are modified', async () => {
+    const packages = await listPackages({ cwd: projectPath });
+    const externalFilePath = path.resolve(projectPath, 'external-src/main.c');
+
+    const changedPackages = await getAllPackagesChangedBasedOnFilesModified([externalFilePath], packages, projectPath);
+
+    const changedNames = changedPackages.map(p => p.name).sort();
+    expect(changedNames).toEqual(['another-wasm-pkg', 'wasm-pkg']);
+    for (const pkg of changedPackages) {
+      expect(pkg.filesChanged).toContain(externalFilePath);
+    }
+  });
+
+  it('should not attribute external file changes to packages without additionalPaths', async () => {
+    const packages = await listPackages({ cwd: projectPath });
+    const externalFilePath = path.resolve(projectPath, 'external-src/main.c');
+
+    const changedPackages = await getAllPackagesChangedBasedOnFilesModified([externalFilePath], packages, projectPath);
+
+    const regularPkg = changedPackages.find(p => p.name === 'regular-pkg');
+    expect(regularPkg).toBeUndefined();
+  });
+
+  it('should still detect changes to files within the package directory itself', async () => {
+    const packages = await listPackages({ cwd: projectPath });
+    const wasmPkg = packages.find(p => p.name === 'wasm-pkg')!;
+    const internalFilePath = path.join(wasmPkg.packagePath, 'src/index.ts');
+
+    const changedPackages = await getAllPackagesChangedBasedOnFilesModified([internalFilePath], packages, projectPath);
+
+    expect(changedPackages.length).toBe(1);
+    expect(changedPackages[0]!.name).toBe('wasm-pkg');
+  });
+
+  it('should handle both internal and external file changes for the same package', async () => {
+    const packages = await listPackages({ cwd: projectPath });
+    const wasmPkg = packages.find(p => p.name === 'wasm-pkg')!;
+    const internalFilePath = path.join(wasmPkg.packagePath, 'src/index.ts');
+    const externalFilePath = path.resolve(projectPath, 'external-src/main.c');
+
+    const changedPackages = await getAllPackagesChangedBasedOnFilesModified(
+      [internalFilePath, externalFilePath],
+      packages,
+      projectPath,
+    );
+
+    const wasmChanged = changedPackages.find(p => p.name === 'wasm-pkg');
+    expect(wasmChanged).toBeDefined();
+    expect(wasmChanged!.filesChanged).toContain(internalFilePath);
+    expect(wasmChanged!.filesChanged).toContain(externalFilePath);
+
+    const anotherChanged = changedPackages.find(p => p.name === 'another-wasm-pkg');
+    expect(anotherChanged).toBeDefined();
+    expect(anotherChanged!.filesChanged).toContain(externalFilePath);
+    expect(anotherChanged!.filesChanged).not.toContain(internalFilePath);
+  });
+
+  it('should bump multiple packages that share the same additionalPath', async () => {
+    const packages = await listPackages({ cwd: projectPath });
+    const externalFilePath = path.resolve(projectPath, 'external-src/main.c');
+
+    const changedPackages = await getAllPackagesChangedBasedOnFilesModified([externalFilePath], packages, projectPath);
+
+    const changedNames = changedPackages.map(p => p.name).sort();
+    expect(changedNames).toEqual(['another-wasm-pkg', 'wasm-pkg']);
+    expect(changedPackages.find(p => p.name === 'regular-pkg')).toBeUndefined();
+  });
+
+  it('should default allPaths to [packagePath] when no additionalPaths configured', () => {
+    const pkg = new PackageInfo({
+      isPrivate: false,
+      name: 'test-pkg',
+      packagePath: '/some/path',
+      packageJSONPath: '/some/path/package.json',
+      pkg: { name: 'test-pkg', version: '1.0.0' },
+      root: false,
+      version: '1.0.0',
+    });
+
+    expect(pkg.additionalPaths).toEqual([]);
+    expect(pkg.allPaths).toEqual(['/some/path']);
+  });
+
+  it('should include additionalPaths in allPaths when provided', () => {
+    const pkg = new PackageInfo({
+      additionalPaths: ['/external/a', '/external/b'],
+      isPrivate: false,
+      name: 'test-pkg',
+      packagePath: '/some/path',
+      packageJSONPath: '/some/path/package.json',
+      pkg: { name: 'test-pkg', version: '1.0.0' },
+      root: false,
+      version: '1.0.0',
+    });
+
+    expect(pkg.additionalPaths).toEqual(['/external/a', '/external/b']);
+    expect(pkg.allPaths).toEqual(['/some/path', '/external/a', '/external/b']);
+  });
+});

--- a/src/__test__/dummyProjects/multiNPMWithAdditionalPaths/external-src/main.c
+++ b/src/__test__/dummyProjects/multiNPMWithAdditionalPaths/external-src/main.c
@@ -1,0 +1,1 @@
+int main() { return 0; }

--- a/src/__test__/dummyProjects/multiNPMWithAdditionalPaths/letsVersion.config.mjs
+++ b/src/__test__/dummyProjects/multiNPMWithAdditionalPaths/letsVersion.config.mjs
@@ -1,0 +1,10 @@
+export default {
+  packages: {
+    "wasm-pkg": {
+      additionalPaths: ["../../external-src"],
+    },
+    "another-wasm-pkg": {
+      additionalPaths: ["../../external-src"],
+    },
+  },
+};

--- a/src/__test__/dummyProjects/multiNPMWithAdditionalPaths/package.json
+++ b/src/__test__/dummyProjects/multiNPMWithAdditionalPaths/package.json
@@ -1,0 +1,6 @@
+{
+  "private": true,
+  "name": "multi-package-additional-paths",
+  "workspaces": ["./packages/*"],
+  "version": "0.0.0"
+}

--- a/src/__test__/dummyProjects/multiNPMWithAdditionalPaths/packages/another-wasm-pkg/package.json
+++ b/src/__test__/dummyProjects/multiNPMWithAdditionalPaths/packages/another-wasm-pkg/package.json
@@ -1,0 +1,5 @@
+{
+  "private": true,
+  "name": "another-wasm-pkg",
+  "version": "1.0.0"
+}

--- a/src/__test__/dummyProjects/multiNPMWithAdditionalPaths/packages/regular-pkg/package.json
+++ b/src/__test__/dummyProjects/multiNPMWithAdditionalPaths/packages/regular-pkg/package.json
@@ -1,0 +1,5 @@
+{
+  "private": true,
+  "name": "regular-pkg",
+  "version": "1.0.0"
+}

--- a/src/__test__/dummyProjects/multiNPMWithAdditionalPaths/packages/wasm-pkg/package.json
+++ b/src/__test__/dummyProjects/multiNPMWithAdditionalPaths/packages/wasm-pkg/package.json
@@ -1,0 +1,5 @@
+{
+  "private": true,
+  "name": "wasm-pkg",
+  "version": "1.0.0"
+}

--- a/src/getPackages.ts
+++ b/src/getPackages.ts
@@ -1,14 +1,35 @@
 import mapWorkspaces from '@npmcli/map-workspaces';
 import appRootPath from 'app-root-path';
 import { promises as fs } from 'fs';
+import fsSync from 'fs';
 import path from 'path';
 import { PackageJson } from 'type-fest';
 
 import { fixCWD } from './cwd.js';
 import { exec } from './exec.js';
 import { getPackageManager } from './getPackageManager.js';
+import { LetsVersionConfig, readLetsVersionConfig } from './readUserConfig.js';
 import { PackageInfo } from './types.js';
+import { isUnderPath } from './util.js';
 import { detectIfMonorepo } from './workspaces.js';
+
+/**
+ * Resolves and validates additionalPaths for a package.
+ * Paths are resolved relative to the package directory. Throws if any
+ * resolved path does not exist on disk.
+ */
+function resolveAdditionalPaths(packageName: string, packagePath: string, rawPaths: string[]): string[] {
+  return rawPaths.map(p => {
+    const resolved = path.resolve(packagePath, p);
+    if (!fsSync.existsSync(resolved)) {
+      throw new Error(
+        `additionalPaths entry "${p}" for package "${packageName}" resolved to "${resolved}" which does not exist. ` +
+          `Paths in letsVersion.config.mjs are resolved relative to the package directory ("${packagePath}").`,
+      );
+    }
+    return resolved;
+  });
+}
 
 /**
  * Tries to figure out what all packages live in repository.
@@ -17,9 +38,10 @@ import { detectIfMonorepo } from './workspaces.js';
  * We will leave the responsibilty of updating the "root" monorepo package
  * to the user. They can use this library, but it will be opt-in.
  */
-export async function getPackages(cwd = appRootPath.toString()) {
+export async function getPackages(cwd = appRootPath.toString(), config?: LetsVersionConfig | null) {
   const fixedCWD = fixCWD(cwd);
   const pm = await getPackageManager(fixedCWD);
+  const resolvedConfig = config ?? (await readLetsVersionConfig(fixedCWD));
 
   const rootPJSONPath = path.join(fixedCWD, 'package.json');
 
@@ -56,11 +78,21 @@ export async function getPackages(cwd = appRootPath.toString()) {
     });
   }
 
+  const rootPackagePath = path.dirname(rootPJSONPath);
+  const rootName = rootPJSON.name || '';
+  const rootPkgConfig = resolvedConfig?.packages?.[rootName];
+  const rootAdditionalPaths = resolveAdditionalPaths(
+    rootName,
+    rootPackagePath,
+    rootPkgConfig?.additionalPaths ?? [],
+  );
+
   const rootPackage = new PackageInfo({
+    additionalPaths: rootAdditionalPaths,
     isPrivate: rootPJSON.private || false,
-    name: rootPJSON.name || '',
+    name: rootName,
     packageJSONPath: rootPJSONPath,
-    packagePath: path.dirname(rootPJSONPath),
+    packagePath: rootPackagePath,
     pkg: rootPJSON,
     root: true,
     version: rootPJSON.version || '',
@@ -70,7 +102,11 @@ export async function getPackages(cwd = appRootPath.toString()) {
     Array.from(workspaces.entries()).map(async ([name, packagePath]) => {
       const pjson = JSON.parse(await fs.readFile(path.join(packagePath, 'package.json'), 'utf8')) as PackageJson;
 
+      const pkgConfig = resolvedConfig?.packages?.[name];
+      const additionalPaths = resolveAdditionalPaths(name, packagePath, pkgConfig?.additionalPaths ?? []);
+
       return new PackageInfo({
+        additionalPaths,
         isPrivate: pjson.private ?? false,
         name,
         packagePath,
@@ -101,8 +137,8 @@ export async function getAllPackagesChangedBasedOnFilesModified(
   const out = new Map<string, PackageInfo>();
 
   for (const filePath of filesModified) {
-    const touchedPackage = packagesToCheck.find(p => filePath.includes(p.packagePath));
-    if (touchedPackage) {
+    const touchedPackages = packagesToCheck.filter(p => p.allPaths.some(ap => isUnderPath(filePath, ap)));
+    for (const touchedPackage of touchedPackages) {
       const prevTrackedTouchedPackage = out.get(touchedPackage.name);
       const updatedPackage = new PackageInfo({
         ...touchedPackage,

--- a/src/git.ts
+++ b/src/git.ts
@@ -8,7 +8,7 @@ import { fixCWD } from './cwd.js';
 import { exec } from './exec.js';
 import { parseToConventional } from './parser.js';
 import { GitCommit, GitCommitWithConventionalAndPackageInfo, PackageInfo, PublishTagInfo } from './types.js';
-import { chunkArray } from './util.js';
+import { chunkArray, isUnderPath } from './util.js';
 
 let didFetchAll = false;
 /**
@@ -52,7 +52,7 @@ export interface GitCommitsSinceOpts {
   commitDateFormat?: string;
   cwd?: string;
   since?: string;
-  relPath?: string;
+  relPath?: string | string[];
 }
 /**
  * Returns commits since a particular git SHA or tag.
@@ -60,7 +60,7 @@ export interface GitCommitsSinceOpts {
  * from the dawn of man are returned
  */
 export async function gitCommitsSince(opts?: GitCommitsSinceOpts): Promise<GitCommit[]> {
-  const { cwd = appRootPath.toString(), commitDateFormat = 'iso-strict', relPath = '', since = '' } = opts ?? {};
+  const { cwd = appRootPath.toString(), commitDateFormat = 'iso-strict', relPath = [], since = '' } = opts ?? {};
   const fixedCWD = fixCWD(cwd);
 
   let cmd = 'git --no-pager log';
@@ -71,7 +71,10 @@ export async function gitCommitsSince(opts?: GitCommitsSinceOpts): Promise<GitCo
   cmd += ` --format=${DELIMITER}%H${DELIMITER}%an${DELIMITER}%ae${DELIMITER}%ad${DELIMITER}%B${LINE_DELIMITER}`;
   if (commitDateFormat) cmd += ` --date=${commitDateFormat}`;
   if (since) cmd += ` ${since}..`;
-  if (relPath) cmd += ` -- ${relPath}`;
+
+  const relPaths = Array.isArray(relPath) ? relPath : [relPath];
+  const nonEmptyPaths = relPaths.filter(Boolean);
+  if (nonEmptyPaths.length) cmd += ` -- ${nonEmptyPaths.map(p => `"${p}"`).join(' ')}`;
 
   const stdout = await exec(cmd, { cwd: fixedCWD, stdio: 'pipe' });
 
@@ -271,7 +274,7 @@ export async function getAllFilesChangedSinceTagInfos(
         // we'll guard just to silence the compiler
         if (!pkg) return results;
 
-        return results.filter(fp => fp.startsWith(pkg.packagePath));
+        return results.filter(fp => pkg.allPaths.some(p => isUnderPath(fp, p)));
       }),
     )
   ).flat();
@@ -293,7 +296,7 @@ export async function getAllFilesChangedSinceBranch(
 
   const results = filteredPackages
     .map(pkg => {
-      return allFiles.filter(fp => fp.startsWith(pkg.packagePath));
+      return allFiles.filter(fp => pkg.allPaths.some(p => isUnderPath(fp, p)));
     })
     .flat();
 
@@ -316,7 +319,7 @@ export async function gitConventionalForPackage(
 
   if (!noFetchAll) gitFetchAll(fixedCWD);
   const taginfo = await gitLastKnownPublishTagInfoForPackage(packageInfo, fixedCWD);
-  const relPackagePath = path.relative(cwd, packageInfo.packagePath);
+  const relPaths = packageInfo.allPaths.map(p => path.relative(cwd, p));
 
   // in a prior version of lets-version, we used to error out if there wasn't a previous publish at all,
   // which wasn't great, as it meant that you needed at least one publish to use this library in your repo.
@@ -325,7 +328,7 @@ export async function gitConventionalForPackage(
   const results = await gitCommitsSince({
     ...rest,
     cwd: fixedCWD,
-    relPath: relPackagePath,
+    relPath: relPaths,
     since: taginfo?.sha ?? undefined,
   });
   const conventional = parseToConventional(results);

--- a/src/readUserConfig.ts
+++ b/src/readUserConfig.ts
@@ -10,8 +10,61 @@ export interface ChangelogConfig {
   changeLogRollupFormatter?: ChangeLogRollupFormatter;
 }
 
+/**
+ * Per-package configuration options in letsVersion.config.mjs.
+ */
+export interface LetsVersionPackageConfig {
+  /**
+   * Additional filesystem paths whose changes should trigger a version bump
+   * for this package. Useful when a package depends on source files that live
+   * outside its own directory (e.g. native C/C++ sources consumed by a WASM
+   * package).
+   *
+   * Paths are resolved **relative to the package directory**, not the
+   * repository root. For example, if your repo looks like:
+   *
+   * ```
+   * /
+   *   c-src/
+   *   js/
+   *     packages/
+   *       wasm-pkg/       <-- package directory
+   * ```
+   *
+   * To watch `c-src/` for changes to `wasm-pkg`, you would configure:
+   *
+   * ```js
+   * // letsVersion.config.mjs
+   * export default {
+   *   packages: {
+   *     "wasm-pkg": {
+   *       additionalPaths: ["../../../c-src"],
+   *     },
+   *   },
+   * };
+   * ```
+   *
+   * Multiple packages may reference the same additional path — a change in
+   * that path will trigger a version bump for all of them.
+   *
+   * Each path must point to an existing directory or file on disk; an error
+   * is thrown at startup if a resolved path does not exist.
+   */
+  additionalPaths?: string[];
+}
+
+/**
+ * Root configuration for letsVersion.config.mjs.
+ */
 export interface LetsVersionConfig {
+  /** Changelog formatting overrides. */
   changelog?: ChangelogConfig;
+
+  /**
+   * Per-package overrides, keyed by the package `name` field from its
+   * package.json. See {@link LetsVersionPackageConfig} for available options.
+   */
+  packages?: Record<string, LetsVersionPackageConfig>;
 }
 
 /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -191,6 +191,7 @@ export class GitCommitWithConventionalAndPackageInfo extends GitCommitWithConven
 }
 
 export interface PackageInfoOpts {
+  additionalPaths?: string[];
   filesChanged?: string[];
   isPrivate: boolean;
   name: string;
@@ -202,6 +203,8 @@ export interface PackageInfoOpts {
 }
 
 export class PackageInfo {
+  additionalPaths: string[];
+  allPaths: string[];
   isPrivate: boolean;
   name: string;
   packageJSONPath: string;
@@ -211,7 +214,19 @@ export class PackageInfo {
   version: string;
   filesChanged?: string[];
 
-  constructor({ filesChanged, isPrivate, name, packageJSONPath, packagePath, pkg, root, version }: PackageInfoOpts) {
+  constructor({
+    additionalPaths,
+    filesChanged,
+    isPrivate,
+    name,
+    packageJSONPath,
+    packagePath,
+    pkg,
+    root,
+    version,
+  }: PackageInfoOpts) {
+    this.additionalPaths = additionalPaths ?? [];
+    this.allPaths = [packagePath, ...this.additionalPaths];
     this.isPrivate = isPrivate;
     this.name = name;
     this.packageJSONPath = packageJSONPath;

--- a/src/util.ts
+++ b/src/util.ts
@@ -58,6 +58,16 @@ export function isPackageJSONDependencyKeySupported(
 }
 
 /**
+ * Returns true if `filePath` is located inside `basePath`.
+ * Uses a trailing path separator to avoid false prefix matches
+ * (e.g. `/foo/bar-baz/file` should NOT match base `/foo/bar`).
+ */
+export function isUnderPath(filePath: string, basePath: string): boolean {
+  const normalized = basePath.endsWith(path.sep) ? basePath : basePath + path.sep;
+  return filePath.startsWith(normalized) || filePath === basePath;
+}
+
+/**
  * Left-indents content to a certain depth
  */
 export function indentStr(content: string, indentChar = ' ', depth = 0) {


### PR DESCRIPTION
We have a package that uses WASM and depends on some source files that live outside the package directory. Our repo looks something like this:

```
/
  c/
  js/
    packages/
       wasm/
```

We'd like a commit that _only_ affects files in `c/` to cause a version bump to the `wasm` package. As far as I can tell, previously there was no way to do this since lets-version only looked at git commits within the package's own directory (`wasm/`).

This PR adds a `packages` map to `letsVersion.config.mjs` where you can specify `additionalPaths` per package. When deciding if a version bump is needed, changes to those paths are treated as changes to the package.

Another approach I considered was updating package.json to have a list of additional paths. I went with the `letsVersion.config.mjs` approach for vague consistency with [turborepo's `inputs`](https://turborepo.dev/docs/crafting-your-repository/configuring-tasks#specifying-inputs ).

Used Claude Opus 4.6 to do this PR, with review/planning by me. Happy to make any changes/cleanup you'd suggest (and would be thrilled to close it if there's a cleaner way to solve this problem!)

Rest of the PR description is from Claude:

### Example config

For the repo structure above, the config at the repo root would be:

```js
// letsVersion.config.mjs
export default {
  packages: {
    "wasm": {
      additionalPaths: ["../../../c"],
    },
  },
};
```

### Validation

Each path is validated at startup. If a resolved path doesn't exist, you get an error:

```
additionalPaths entry "../../nonexistent-dir" for package "wasm-pkg" resolved to
"/repo/nonexistent-dir" which does not exist. Paths in letsVersion.config.mjs are
resolved relative to the package directory ("/repo/js/packages/wasm").
```

## Additional fixes

### Multiple packages can share the same additional path

The pre-existing code used `Array.find()` when matching modified files to packages, since paths were 1:1 with packages. This PR switches to `Array.filter()`, in case two packages both depend on the same external path.

### Path matching boundary safety

The pre-existing code used bare `String.startsWith()` and `String.includes()` for matching file paths against package paths. Since `packagePath` never includes a trailing separator (it comes from `path.dirname()`), this could produce false positives — e.g., `/repo/src-other/file.ts` would match a package rooted at `/repo/src`. This seems unlikely in practice since package directory names tend to be unique, but it felt worth fixing.

This PR introduces an `isUnderPath(filePath, basePath)` utility that normalizes the base path with a trailing separator before comparison, and uses it at all path-matching call sites.

### Quoted paths in git commands

When this PR passes multiple paths to `git log -- <paths>`, each path is individually quoted to handle paths containing spaces. (The pre-existing single-path code didn't need this since git handles a single unquoted path fine.)